### PR TITLE
Fixando versão 1.0.0alpha7 do PHPSC/pagseguro no composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "wesleywillians/laravel-pagseguro",
     "description": "Laravel 5 ServiceProvider for Pagseguro Library from PHPSC",
     "require": {
-        "phpsc/pagseguro": "1.0.*"
+        "phpsc/pagseguro": "1.0.0alpha7"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
Ao dar um composer install, está sendo instalado uma versão não compatível do **PHPSC/pagseguro**. 
Com isso a classe **PHPSC\PagSeguro\Requests\Checkout\CheckoutService** não é encontrada.
Portanto é necessário fixar a versão **1.0.0alpha7** para certificar que será instalado a versão compatível, que contem a classe CheckoutService.
